### PR TITLE
3 add support for userinfo endpoint

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -13,10 +13,12 @@ $view = match($path) {
     '/' => 'home.php',
     '/get-user-information', '/api/v1/contracts/bank-id' => 'get_profile.php',
     '/sign-document' => 'sign_document.php',
+    '/logout' => 'logout.php',
     default => null,
 };
 
 if ($view === null) {
+    http_response_code(404);
     echo '404 not found';
     exit;
 }

--- a/examples/views/get_profile.php
+++ b/examples/views/get_profile.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Unnits\BankId\Client as BankIdClient;
 use GuzzleHttp\Client as GuzzleClient;
 use Unnits\BankId\Enums\Scope;
+use Unnits\BankId\LogoutUri;
 
 /**
  * MUST match one of the Redirect URIs in BankId's developer portal
  */
 $redirectUri = 'http://localhost:8000/api/v1/contracts/bank-id';
+
+$logoutRedirectUri = 'http://localhost:8000/logout';
 
 $client = new BankIdClient(
     httpClient: new GuzzleClient,
@@ -32,6 +35,8 @@ if ($path === parse_url($redirectUri, PHP_URL_PATH)) {
     $tokenInfo = $client->getTokenInfo($token, useClientCredentials: true);
 
     $documentUri = $token->identityToken->structuredScope->documentObject->documentUri ?? null;
+
+    $logoutUri = (string)$client->getLogoutUri($token->identityToken->rawValue ?? '', $logoutRedirectUri, '12345');
 }
 
 $state = '1234';
@@ -57,12 +62,23 @@ $link = (string)$client->getAuthUri($state, scopes: [
             <span>Sign In with Bank iD</span>
         </a>
     <?php else: ?>
-        <a href="/">Back</a>
+        <ul>
+            <li><a href="/">Back</a></li>
 
-        <?php if (!empty($documentUri)): ?>
-            <br>
-            <a href="<?= $documentUri ?>">Download signed document</a>
-        <?php endif; ?>
+
+            <li>
+                <form
+                    method="post"
+                    action="<?= $logoutUri ?>"
+                >
+                    <button class="logout-button" type="submit">Logout</button>
+                </form>
+            </li>
+
+            <?php if (!empty($documentUri)): ?>
+                <li><a href="<?= $documentUri ?>">Download signed document</a></li>
+            <?php endif; ?>
+        </ul>
 
         <ul>
             <li>Given name: <?= $profile->givenName ?></li>

--- a/examples/views/get_profile.php
+++ b/examples/views/get_profile.php
@@ -37,6 +37,8 @@ if ($path === parse_url($redirectUri, PHP_URL_PATH)) {
     $documentUri = $token->identityToken->structuredScope->documentObject->documentUri ?? null;
 
     $logoutUri = (string)$client->getLogoutUri($token->identityToken->rawValue ?? '', $logoutRedirectUri, '12345');
+
+    $userInfo = $client->getUserInfo($token);
 }
 
 $state = '1234';
@@ -90,6 +92,12 @@ $link = (string)$client->getAuthUri($state, scopes: [
 
         <h2>Profile</h2>
         <pre><code><?= print_r($profile, true) ?></code></pre>
+
+        <?php if (isset($userInfo)): ?>
+            <h2>User info</h2>
+
+            <pre><code><?= print_r($userInfo, true) ?></code></pre>
+        <?php endif; ?>
 
         <?php if (isset($token)): ?>
             <h2>Access Token</h2>

--- a/examples/views/header.php
+++ b/examples/views/header.php
@@ -39,6 +39,15 @@
             border-right: 1px solid white;
         }
 
+        .logout-button {
+            border: 0;
+            background: none;
+            padding: 0;
+            text-decoration: underline;
+            color: blue;
+            cursor: pointer;
+        }
+
         pre {
             background: #eee;
             padding: 20px;

--- a/examples/views/home.php
+++ b/examples/views/home.php
@@ -1,14 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Unnits/BankIdClient</title>
-</head>
-
-<body>
-    <ul>
-        <li><a href="/get-user-information">Receiving user profile information using BankiD</a></li>
-        <li><a href="/sign-document">Digitally signing documents using BankiD</a></li>
-    </ul>
-</body>
-</html>
+<ul>
+    <li><a href="/get-user-information">Receiving user profile information using BankiD</a></li>
+    <li><a href="/sign-document">Digitally signing documents using BankiD</a></li>
+</ul>

--- a/examples/views/logout.php
+++ b/examples/views/logout.php
@@ -1,0 +1,5 @@
+<h1>Logout success!</h1>
+
+<p>You have been successfully logged out!</p>
+
+<a href="/">Go back home</a> 👋

--- a/src/AuthorizationUri.php
+++ b/src/AuthorizationUri.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Unnits\BankId;
 
+use Stringable;
 use Unnits\BankId\Enums\AcrValue;
 use Unnits\BankId\Enums\AuthorizationUriQueryParameter as QueryParam;
 use Unnits\BankId\Enums\CodeChallengeMethod;
 use Unnits\BankId\Enums\ResponseType;
 use Unnits\BankId\Enums\Scope;
 
-final class AuthorizationUri
+final class AuthorizationUri implements Stringable
 {
     /**
      * @param string $baseUri

--- a/src/DTO/AuthToken.php
+++ b/src/DTO/AuthToken.php
@@ -50,7 +50,8 @@ class AuthToken
             new CompactSerializer()
         ]);
 
-        $jwt = $serializerManager->unserialize(strval($data['id_token']));
+        $rawIdToken = strval($data['id_token']);
+        $jwt = $serializerManager->unserialize($rawIdToken);
         $payload = Utils::jsonDecode($jwt->getPayload() ?? '', assoc: true);
 
         assert(is_array($payload));
@@ -60,7 +61,7 @@ class AuthToken
             tokenType: TokenType::from(strtolower(strval($data['token_type']))),
             expiresIn: intval($data['expires_in']),
             scopes: $scopes,
-            identityToken: IdentityToken::create($payload),
+            identityToken: IdentityToken::create($payload, $rawIdToken),
         );
     }
 }

--- a/src/DTO/IdentityToken.php
+++ b/src/DTO/IdentityToken.php
@@ -24,6 +24,7 @@ class IdentityToken
         public readonly ?string $nonce = null,
         public readonly ?string $sid = null,
         public readonly ?string $name = null,
+        public readonly ?string $rawValue = null,
     ) {
         //
     }
@@ -33,7 +34,7 @@ class IdentityToken
      * @return self
      * @throws Exception
      */
-    public static function create(array $data): self
+    public static function create(array $data, ?string $rawValue = null): self
     {
         return new self(
             sub: $data['sub'],
@@ -53,6 +54,7 @@ class IdentityToken
             nonce: $data['nonce'] ?? null,
             sid: $data['sid'] ?? null,
             name: $data['name'] ?? null,
+            rawValue: $rawValue,
         );
     }
 }

--- a/src/DTO/UserInfo.php
+++ b/src/DTO/UserInfo.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unnits\BankId\DTO;
+
+use Unnits\BankId\Enums\Gender;
+
+class UserInfo
+{
+    public function __construct(
+        public readonly string $customerUuid,
+        public readonly string $transactionIdentifier,
+        public readonly ?VerifiedClaims $verifiedClaims,
+        public readonly ?string $name,
+        public readonly ?string $givenName,
+        public readonly ?string $familyName,
+        public readonly ?string $middleName,
+        public readonly ?string $nickname,
+        public readonly ?string $preferredUsername,
+        public readonly ?string $email,
+        public readonly ?bool $emailVerified,
+        public readonly ?Gender $gender,
+        public readonly ?string $birthDate,
+        public readonly ?string $timezone,
+        public readonly ?string $locale,
+        public readonly ?string $phoneNumber,
+        public readonly ?bool $phoneNumberVerified,
+        public readonly ?string $updatedAt,
+    ) {
+        //
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function create(array $data): self
+    {
+        $verifiedClaims = array_key_exists('verified_claims', $data)
+            ? VerifiedClaims::create($data['verified_claims'])
+            : null;
+
+        $emailVerified = array_key_exists('email_verified', $data)
+            ? (bool)$data['email_verified']
+            : null;
+
+        $gender = array_key_exists('gender', $data)
+            ? Gender::from($data['gender'])
+            : null;
+
+        $phoneVerified = array_key_exists('phone_number_verified', $data)
+            ? (bool)$data['phone_number_verified']
+            : null;
+
+        $updatedAt = array_key_exists('updated_at', $data)
+            ? (bool)$data['updated_at']
+            : null;
+
+        return new self(
+            $data['sub'],
+            $data['txn'],
+            $verifiedClaims,
+            $data['name'] ?? null,
+            $data['givenName'] ?? null,
+            $data['familyName'] ?? null,
+            $data['middleName'] ?? null,
+            $data['nickname'] ?? null,
+            $data['preferred_username'] ?? null,
+            $data['email'] ?? null,
+            $emailVerified,
+            $gender,
+            $data['birthdate'] ?? null,
+            $data['zoneinfo'] ?? null,
+            $data['locale'] ?? null,
+            $data['phone_number'] ?? null,
+            $phoneVerified,
+            $updatedAt,
+        );
+    }
+}

--- a/src/DTO/VerifiedClaims.php
+++ b/src/DTO/VerifiedClaims.php
@@ -25,7 +25,7 @@ class VerifiedClaims
     {
         return new self(
             array_key_exists('verification', $data) ? Verification::create($data['verification']) : null,
-            $data['claims_profile'] ?? [],
+            $data['claims'] ?? [],
         );
     }
 }

--- a/src/Enums/LogoutUriQueryParameter.php
+++ b/src/Enums/LogoutUriQueryParameter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unnits\BankId\Enums;
+
+enum LogoutUriQueryParameter: string
+{
+    case IdTokenHint = 'id_token_hint';
+    case RedirectUri = 'post_logout_redirect_uri';
+    case State = 'state';
+}

--- a/src/Exceptions/LogoutException.php
+++ b/src/Exceptions/LogoutException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unnits\BankId\Exceptions;
+
+use Exception;
+
+class LogoutException extends Exception
+{
+    //
+}

--- a/src/LogoutUri.php
+++ b/src/LogoutUri.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unnits\BankId;
+
+use Stringable;
+use Unnits\BankId\DTO\IdentityToken;
+use Unnits\BankId\Enums\LogoutUriQueryParameter as QueryParam;
+
+final class LogoutUri implements Stringable
+{
+    public function __construct(
+        private readonly string $baseUri,
+        private readonly string|IdentityToken $idTokenHint,
+        private readonly ?string $redirectUri = null,
+        private readonly ?string $state = null,
+    ) {
+        //
+    }
+
+    public function __toString(): string
+    {
+        $params = [];
+
+        $params[QueryParam::IdTokenHint->value] = $this->idTokenHint instanceof IdentityToken
+            ? $this->idTokenHint->rawValue ?? ''
+            : strval($this->idTokenHint);
+
+        if ($this->redirectUri !== null) {
+            $params[QueryParam::RedirectUri->value] = $this->redirectUri;
+        }
+
+        if ($this->state !== null) {
+            $params[QueryParam::State->value] = $this->state;
+        }
+
+        return sprintf(
+            '%s/logout?%s',
+            trim($this->baseUri, '/'),
+            http_build_query($params),
+        );
+    }
+}


### PR DESCRIPTION
This PR contains one bugfix and one enhancement:

1. bugfix: `VerifiedClaims` DTO tried to find `claims_profile` to use it as `$claims` property. The correct key to look for is `claims` (see https://developer.bankid.cz/docs/api/bankid-for-sep search for `verified_claims_userinfo`)
2. enhancement: Added client method for reading UserInfo via /userinfo endpoint