### PR TITLE
Make signature algorithm configurable in `createRequestObject` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made signature algorithm configurable in `createRequestObject` method
+
 ## [0.7.0] - 2024-08-09
 
 ### Added


### PR DESCRIPTION
# Description
This proposed change introduces `SignatureAlgorithm` as an optional parameter with a default value of **RS256** to maintain backward compatibility.

# Intent
The purpose of this change is to expand support for a wider range of JWT token types, including those using EC algorithms (e.g., **ES256**). 

# Related Issue
GitHub Issue: [[https://github.com/unnits/bankid-php-client/issues/2](https://github.com/unnits/bankid-php-client/issues/26)](https://github.com/unnits/bankid-php-client/issues/26)

