### PR TITLE
Fix: Use configurable baseUri for banks API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+ 
 - Fixed banks API endpoint to use the configured baseUri instead of hardcoded URL
 
 ## [0.9.0] - 2025-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed banks API endpoint to use the configured baseUri instead of hardcoded URL
+
 ## [0.9.0] - 2025-06-30
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -218,7 +218,7 @@ class Client
     {
         $request = new Request(
             method: 'GET',
-            uri: 'https://oidc.bankid.cz/api/v1/banks',
+            uri: sprintf('%s/api/v1/banks', $this->baseUri)
         );
 
         $response = $this->httpClient->sendRequest($request);


### PR DESCRIPTION
**Description:**
This proposed change ensures that the banks API endpoint uses the configured `baseUri` when making requests, replacing the previous hardcoded URL.

**Problem:**
It is not possible to retrieve mock banks from the sandbox baseUri with the current hardcoded URL. This fix resolves the issue by using the proper configured `baseUri`.
