### PR TITLE
  Add transactionIdentifier parameter to the Profile DTO

### DIFF
--- a/src/DTO/Profile.php
+++ b/src/DTO/Profile.php
@@ -10,6 +10,7 @@ class Profile
 {
     /**
      * @param string|null $customerUuid
+     * @param string $transactionIdentifier
      * @param string|null $givenName
      * @param string|null $familyName
      * @param string|null $titlePrefix
@@ -35,8 +36,10 @@ class Profile
      * @param int|null $updatedAt
      * @param ?VerifiedClaims $verifiedClaims
      */
+
     public function __construct(
         public readonly ?string $customerUuid,
+        public readonly string $transactionIdentifier,
         public readonly ?string $givenName,
         public readonly ?string $familyName,
         public readonly ?string $titlePrefix,
@@ -88,6 +91,7 @@ class Profile
 
         return new self(
             $data['sub'] ?? null,
+            $data['txn'],
             $data['given_name'] ?? null,
             $data['family_name'] ?? null,
             $data['title_prefix'] ?? null,

--- a/src/DTO/Profile.php
+++ b/src/DTO/Profile.php
@@ -10,7 +10,6 @@ class Profile
 {
     /**
      * @param string|null $customerUuid
-     * @param string $transactionIdentifier
      * @param string|null $givenName
      * @param string|null $familyName
      * @param string|null $titlePrefix
@@ -35,11 +34,11 @@ class Profile
      * @param string[]|null $paymentAccountsDetails
      * @param int|null $updatedAt
      * @param ?VerifiedClaims $verifiedClaims
+     * @param string|null $transactionIdentifier
      */
 
     public function __construct(
         public readonly ?string $customerUuid,
-        public readonly string $transactionIdentifier,
         public readonly ?string $givenName,
         public readonly ?string $familyName,
         public readonly ?string $titlePrefix,
@@ -64,6 +63,7 @@ class Profile
         public readonly ?array $paymentAccountsDetails,
         public readonly ?int $updatedAt,
         public readonly ?VerifiedClaims $verifiedClaims,
+        public readonly ?string $transactionIdentifier = null,
     ) {
         //
     }
@@ -91,7 +91,6 @@ class Profile
 
         return new self(
             $data['sub'] ?? null,
-            $data['txn'],
             $data['given_name'] ?? null,
             $data['family_name'] ?? null,
             $data['title_prefix'] ?? null,
@@ -116,6 +115,7 @@ class Profile
             $data['paymentAccountsDetails'] ?? null,
             $data['updated_at'] ?? null,
             array_key_exists('verified_claims', $data) ? VerifiedClaims::create($data['verified_claims']) : null,
+            $data['txn'] ?? null,
         );
     }
 }

--- a/src/DTO/Profile.php
+++ b/src/DTO/Profile.php
@@ -36,7 +36,6 @@ class Profile
      * @param ?VerifiedClaims $verifiedClaims
      * @param string|null $transactionIdentifier
      */
-
     public function __construct(
         public readonly ?string $customerUuid,
         public readonly ?string $givenName,


### PR DESCRIPTION

###   Description

  Add transactionIdentifier parameter to the Profile DTO.

###   Changes

  - Added new required parameter transactionIdentifier to the Profile class


  Note: Unlike other properties in the DTO, transactionIdentifier is not nullable, as the API documentation specifies it as a required string field. This aligns with how the UserInfo class is structured, where this element is also non-nullable.

###   Reason

  The transactionIdentifier parameter is returned by the BankID API and we are using it as an identifier in the audit log to prove the uniqueness of the document signature.

  Reference: https://developer.bankid.cz/docs/api/bankid-for-sep#operations-tag-User_Profile